### PR TITLE
added basic multi-tenancy support

### DIFF
--- a/routes.js
+++ b/routes.js
@@ -13,11 +13,13 @@ router.post('/namespaces/:namespace/actions/:packageName/:actionName', invokeHan
 
 function invokeHandlerWithPackage(req, res) {
   // concatenate /<namespace>/<packageName>/<actionName> and pass as action name
-  req.params.actionName = '/' + req.params.namespace + '/' + req.params.packageName + '/' + req.params.actionName;
+  req.params.actionName = req.params.packageName + '/' + req.params.actionName;
+  console.log("invokehandler with " +  req.params.actionName);
   invokeHandler(req, res);
 }
 
 function invokeHandler(req, res) {
+  req.params.actionName = '/' + req.params.namespace + '/' + req.params.actionName;
   actions.handleInvokeAction(req, res);
 }
 
@@ -26,11 +28,12 @@ router.get('/namespaces/:namespace/actions/:packageName/:actionName', getHandler
 
 function getHandlerWithPackage(req, res) {
   // concatenate /<namespace>/<packageName>/<actionName> and pass as action name
-  req.params.actionName = '/' + req.params.namespace + '/' + req.params.packageName + '/' + req.params.actionName;
+  req.params.actionName = req.params.packageName + '/' + req.params.actionName;
   getHandler(req, res);
 }
 
 function getHandler(req, res) {
+  req.params.actionName = '/' + req.params.namespace + '/' + req.params.actionName;
   actions.handleGetAction(req, res);
 }
 
@@ -39,11 +42,12 @@ router.delete('/namespaces/:namespace/actions/:packageName/:actionName', deleteH
 
 function deleteHandlerWithPackage(req, res) {
   // concatenate /<namespace>/<packageName>/<actionName> and pass as action name
-  req.params.actionName = '/' + req.params.namespace + '/' + req.params.packageName + '/' + req.params.actionName;
+  req.params.actionName = req.params.packageName + '/' + req.params.actionName;
   deleteHandler(req, res);
 }
 
 function deleteHandler(req, res) {
+  req.params.actionName = '/' + req.params.namespace + '/' + req.params.actionName;
   actions.handleDeleteAction(req, res);
 }
 

--- a/test/wsk-actions.bats
+++ b/test/wsk-actions.bats
@@ -13,6 +13,16 @@ teardown() {
   run npm stop --prefix $BASE_DIR
 }
 
+@test "wsk action update owl-test" {
+  run bash -c "wsk -i action update owl-test --kind nodejs:6 $DIR/owl-test.js -p hello world > /dev/null 2>&1"
+  run bash -c "wsk -i action invoke owl-test -r | jq '.hello'"
+  echo $output
+  [ "$output" = "\"world\"" ]
+  run bash -c "wsk -i action invoke owl-test -r --auth WRONG-AUTHORIZATION"
+  echo $output
+  [[ "$output" = *"authentication is invalid"* ]]
+}
+
 @test "wsk action create" {
   run wsk -i action update owl-test --kind nodejs:6 $DIR/owl-test.js 
   [ "$status" -eq 0 ]


### PR DESCRIPTION
resolves #60

- in routes converting actionName to  namespace/[package]/actionName
to store actions in cache by more fine graned key
- actions in cache now have user apikey they been created with
- in case of wrong api key specified throwing error (test added)
- in case api key been changed update action in cache using action get with new api key