### PR TITLE
Added tests for containers preemption

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -14,7 +14,8 @@ const DockerBackend = require('./dockerbackend'),
       backend = (config.preemption && config.preemption.enabled == 'true') ?
                 new DockerBackendWithPreemption({dockerurl: dockerhost}) :
                 new DockerBackend({dockerurl: dockerhost}),
- 
+
+
       retryOptions = {
         max: config.retries.number, 
         timeout: 60000, // TODO: use action time limit?
@@ -31,7 +32,6 @@ const DockerBackend = require('./dockerbackend'),
       actions = {};
 
 console.debug("dockerhost: " + dockerhost);
-
 
  /**
  * Invokes action in Openwhisk light platform
@@ -108,18 +108,18 @@ function handleInvokeAction(req, res) {
           var params = req.body;
           action.parameters.forEach(function(param) { params[param.key]=param.value; });
 		  actionproxy.run(actionContainer, api_key, params).then(function(result){
-            console.debug("invoke request returned with " + result);
-            Object.assign(actionContainer, {'used': process.hrtime()[0], state: STATE.running});
+            console.debug("invoke request returned with " + JSON.stringify(result));
+            backend.invalidateContainer(actionContainer);
             updateAndRespond(actionContainer, activation, result);
             return;
           }).catch(function(err){
             console.error("invoke request failed with " + err);
-            Object.assign(actionContainer, {'used': process.hrtime()[0], state: STATE.running});
+            backend.invalidateContainer(actionContainer);
             updateAndRespond(actionContainer, activation, {}, err);
           });					
         }).catch(function(err){
           console.error("container init failed with " + err);
-          Object.assign(actionContainer, {'used': process.hrtime()[0], state: STATE.running});
+          backend.invalidateContainer(actionContainer);
           updateAndRespond(actionContainer, activation, {}, err);
         });
       }).catch(function (err) {

--- a/dockerBackendWithPreemption.js
+++ b/dockerBackendWithPreemption.js
@@ -46,7 +46,7 @@ class DockerBackendWithPreemption extends DockerBackend {
             var activeContainersNum = 0;
             for(var key in that.containers){
               activeContainers = activeContainers.concat(_.filter(that.containers[key], (o) => {
-                return (o.state != STATE.stopped);
+                return (o.state == STATE.running);
               }));
 
               //  TODO: move inactive containers handling to separate cron job

--- a/test/owl-sleep-test.js
+++ b/test/owl-sleep-test.js
@@ -1,15 +1,7 @@
-function main(params) {
-    console.log("params: " + JSON.stringify(params));
-    sleep(params.timeout);
-    console.info("Finished sleeping for " + params.timeout);
-    return params;
-}
-
-function sleep(milliseconds) {
-    console.log("in sleep with " + milliseconds);
-    var start = new Date();
-    console.log("start: " + start);
-    while ((new Date()) - start <= milliseconds ) {}
-    console.log("(new Date()) - start = " + ((new Date()) - start));
-    console.log("finished waiting for " + milliseconds + "msec");
+function main(args) {
+    return new Promise(function(resolve, reject) {
+      setTimeout(function() {
+        resolve({ timeout: args.timeout });
+      }, args.timeout);
+   })
 }

--- a/test/owl-sleep-test.js
+++ b/test/owl-sleep-test.js
@@ -1,0 +1,15 @@
+function main(params) {
+    console.log("params: " + JSON.stringify(params));
+    sleep(params.timeout);
+    console.info("Finished sleeping for " + params.timeout);
+    return params;
+}
+
+function sleep(milliseconds) {
+    console.log("in sleep with " + milliseconds);
+    var start = new Date();
+    console.log("start: " + start);
+    while ((new Date()) - start <= milliseconds ) {}
+    console.log("(new Date()) - start = " + ((new Date()) - start));
+    console.log("finished waiting for " + milliseconds + "msec");
+}

--- a/test/performance/wsk-preemption.bats
+++ b/test/performance/wsk-preemption.bats
@@ -5,6 +5,8 @@ export OWL_DELEGATE_ON_FAILURE=false
 export OWL_HOST_CAPACITY=5
 export OWL_PREEMPTION_ENABLED=true
 export OWL_PREEMPTION_PERIOD=15
+export OWL_PREEMPTION_LOW=0.25
+export OWL_PREEMPTION_HIGH=0.75
 
 setup() {
   run npm start --prefix $BASE_DIR&
@@ -14,7 +16,9 @@ setup() {
 }
 
 teardown() {
-  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do wsk -i action delete owl-test-$i > /dev/null 2>&1; done
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do
+      wsk -i action delete owl-test-$i > /dev/null 2>&1
+  done
   wsk -i action delete owl-sleep-test > /dev/null 2>&1
   run npm stop --prefix $BASE_DIR
 }
@@ -51,9 +55,11 @@ teardown() {
 
 ########
 # register HOST_CAPACITY action with sleep
-# invoke HOST_CAAPCITY number of actions without blocking to hang for SLEEP_MILLISECONDS and store their activations ids
+# invoke HOST_CAAPCITY number of actions without blocking to hang
+#   for SLEEP_MILLISECONDS and store their activations ids
 # update all the actions above (update + get)
-# wait for TIME > OWL_PREEMPTION_TIME < SLEEP_MILLISECONDS and validate that containers not been preempted
+# wait for TIME > OWL_PREEMPTION_TIME < SLEEP_MILLISECONDS and 
+#   validate that containers not been preempted
 # wait for TIME > SLEEP_MILLISECONDS and check activations result
 # check containers been preempted
 #
@@ -67,7 +73,10 @@ teardown() {
   declare -a activations
 
   sleep 1
-  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do echo "runing wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS"; activations[$i]=`wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS | cut -d' ' -f 6` > /dev/null 2>&1; done
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do
+    echo "runing wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS"
+    activations[$i]=`wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS | cut -d' ' -f 6` > /dev/null 2>&1
+  done
 
   sleep 1
   run bash -c "wsk -i action update owl-sleep-test > /dev/null 2>&1"
@@ -83,9 +92,14 @@ teardown() {
   containersNum=`docker ps|grep nodejs6action|wc -l`
   [ "$containersNum" = "0" ]
 
-  for actid in ${activations[@]}; do res=`wsk -i activation result $actid`; echo "res1: $res"; done
+  for actid in ${activations[@]}; do
+    res=`wsk -i activation result $actid`
+    echo "res1: $res"
+  done
 
-  for actid in ${activations[@]}; do res=`wsk -i activation result $actid | jq .'timeout'`; echo "res2: $res"; [ "$res" = "$SLEEP_MILLISECONDS" ]; done
+  for actid in ${activations[@]}; do
+    res=`wsk -i activation result $actid | jq .'timeout'`; echo "res2: $res"; [ "$res" = "$SLEEP_MILLISECONDS" ]
+  done
 }
 
 ###############################
@@ -98,20 +112,27 @@ teardown() {
 @test "wsk action consume all capacity without delegation and validate action containers been preempted" {
   containersNum=`docker ps|grep nodejs6action|wc -l`
   [ "$containersNum" = "0" ]
-  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do echo "runing wsk -i action update owl-test-$i --kind nodejs:6 $DIR/owl-test.js"; wsk -i action update owl-test-$i --kind nodejs:6 $DIR/owl-test.js > /dev/null 2>&1; done
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do
+    echo "runing wsk -i action update owl-test-$i --kind nodejs:6 $DIR/owl-test.js"
+    wsk -i action update owl-test-$i --kind nodejs:6 $DIR/owl-test.js > /dev/null 2>&1
+  done
 
-  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do echo "runing wsk -i action invoke owl-test-$i"; wsk -i action invoke owl-test-$i > /dev/null 2>&1; done
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do
+    echo "runing wsk -i action invoke owl-test-$i"
+    wsk -i action invoke owl-test-$i > /dev/null 2>&1
+  done
 
   sleep 1
   containersNum=`docker ps|grep nodejs6action|wc -l`
   [ "$containersNum" = "$OWL_HOST_CAPACITY" ]
 
   echo "OWL_PREEMPTION_PERIOD: $OWL_PREEMPTION_PERIOD"
-  date
   sleep $(($OWL_PREEMPTION_PERIOD * 4))
-  date
   containersNum=`docker ps|grep nodejs6action|wc -l`
-  echo $containersNum
-  [ "$containersNum" = "1" ]
+  echo containersNum:$containersNum
+  actualNum=$(expr $OWL_HOST_CAPACITY*$OWL_PREEMPTION_LOW | bc)
+  actualNum=${actualNum%.*}
+  echo actualNum:$actualNum
+  [ "$containersNum" = "$actualNum" ]
 }
 

--- a/test/wsk-owproxy-err.bats
+++ b/test/wsk-owproxy-err.bats
@@ -16,12 +16,5 @@ teardown() {
 
 @test "wsk action invoke on zero capacity without delegation and check activation not created" {
   actid=`wsk -i action invoke owl-test -p aa BB | cut -d' ' -f 6`
-  echo $actid
-#  res=none
-#  run bash -c "wsk -i activation get $actid | jq '.aa'"
-#  for i in {1..5}; do res=`wsk -i activation result $actid | jq '.aa'` && test "$res" != "null" && break || sleep 1; done
-#  echo $res
-#  [ "$res" = "\"BB\"" ]
-  echo actid:$actid
   [ "$actid" = "" ]
 }

--- a/test/wsk-preemption.bats
+++ b/test/wsk-preemption.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+
+load test_helper
+export OWL_DELEGATE_ON_FAILURE=false
+export OWL_HOST_CAPACITY=5
+export OWL_PREEMPTION_ENABLED=true
+export OWL_PREEMPTION_PERIOD=15
+
+setup() {
+  run npm start --prefix $BASE_DIR&
+
+  # long sleep to wait for containers cleanup
+  run bash -c "sleep 20"
+}
+
+teardown() {
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do wsk -i action delete owl-test-$i > /dev/null 2>&1; done
+  wsk -i action delete owl-sleep-test > /dev/null 2>&1
+  run npm stop --prefix $BASE_DIR
+}
+
+########
+# register action with sleep
+# invoke action without blocking to hang for SLEEP_MILLISECONDS
+# update action
+# wait for TIME > SLEEP_MILLISECONDS and check activations result
+# validate action container been removed
+@test "wsk validate action deprecation" {
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  [ "$containersNum" = "0" ]
+
+  SLEEP_MILLISECONDS=10000
+
+  run bash -c "wsk -i action update owl-sleep-test --kind nodejs:6 $DIR/owl-sleep-test.js > /dev/null 2>&1"
+
+  sleep 1
+  actid=`wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS | cut -d' ' -f 6`
+  echo actid:$actid
+
+  run bash -c "wsk -i action update owl-sleep-test > /dev/null 2>&1"
+  run bash -c "wsk -i action get owl-sleep-test > /dev/null 2>&1"
+
+  sleep $(($SLEEP_MILLISECONDS * 2 / 1000))
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  [ "$containersNum" = "0" ]
+
+  res=`wsk -i activation result $actid | jq .'timeout'`
+  echo res:$res
+  [ "$res" = "$SLEEP_MILLISECONDS" ]
+}
+
+########
+# register HOST_CAPACITY action with sleep
+# invoke HOST_CAAPCITY number of actions without blocking to hang for SLEEP_MILLISECONDS and store their activations ids
+# update all the actions above (update + get)
+# wait for TIME > OWL_PREEMPTION_TIME < SLEEP_MILLISECONDS and validate that containers not been preempted
+# wait for TIME > SLEEP_MILLISECONDS and check activations result
+# check containers been preempted
+#
+@test "wsk busy action deprecation and preemption" {
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  [ "$containersNum" = "0" ]
+
+  SLEEP_MILLISECONDS=$((1000 * 3 * $OWL_PREEMPTION_PERIOD))
+
+  run bash -c "wsk -i action update owl-sleep-test --kind nodejs:6 $DIR/owl-sleep-test.js"
+  declare -a activations
+
+  sleep 1
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do echo "runing wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS"; activations[$i]=`wsk -i action invoke owl-sleep-test -p timeout $SLEEP_MILLISECONDS | cut -d' ' -f 6` > /dev/null 2>&1; done
+
+  sleep 1
+  run bash -c "wsk -i action update owl-sleep-test > /dev/null 2>&1"
+  run bash -c "wsk -i action get owl-sleep-test > /dev/null 2>&1"
+
+  sleep $(($OWL_PREEMPTION_PERIOD * 2))
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  echo "containersNum:$containersNum"
+  echo "OWL_HOST_CAPACITY:$OWL_HOST_CAPACITY"
+  [ "$containersNum" = "$OWL_HOST_CAPACITY" ]
+
+  sleep $(($OWL_PREEMPTION_PERIOD * 4))
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  [ "$containersNum" = "0" ]
+
+  for actid in ${activations[@]}; do res=`wsk -i activation result $actid`; echo "res1: $res"; done
+
+  for actid in ${activations[@]}; do res=`wsk -i activation result $actid | jq .'timeout'`; echo "res2: $res"; [ "$res" = "$SLEEP_MILLISECONDS" ]; done
+}
+
+###############################
+# register 5 different actions
+# validate from docker that there no relevant running containers
+# invoke 5 actions
+# validate from docker that there 5 relevant running containers
+# wait for a little bit more than preemption period
+# validate from docker that there 2 relevant running containers now
+@test "wsk action consume all capacity without delegation and validate action containers been preempted" {
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  [ "$containersNum" = "0" ]
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do echo "runing wsk -i action update owl-test-$i --kind nodejs:6 $DIR/owl-test.js"; wsk -i action update owl-test-$i --kind nodejs:6 $DIR/owl-test.js > /dev/null 2>&1; done
+
+  for (( i=0; i<$OWL_HOST_CAPACITY; i++ )); do echo "runing wsk -i action invoke owl-test-$i"; wsk -i action invoke owl-test-$i > /dev/null 2>&1; done
+
+  sleep 1
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  [ "$containersNum" = "$OWL_HOST_CAPACITY" ]
+
+  echo "OWL_PREEMPTION_PERIOD: $OWL_PREEMPTION_PERIOD"
+  date
+  sleep $(($OWL_PREEMPTION_PERIOD * 4))
+  date
+  containersNum=`docker ps|grep nodejs6action|wc -l`
+  echo $containersNum
+  [ "$containersNum" = "1" ]
+}
+


### PR DESCRIPTION
fixes #68
resolves #48

- when action updated, containers associated with old action removed unless container state is allocated or reserved
- deprecated busy containers removed after action invoke finished
- only containers with state running will be preempted
- added tests for container deprecation on action update